### PR TITLE
Fix Kernel.returning deprecation on Rails 2.3.9+.

### DIFF
--- a/lib/gravatar.rb
+++ b/lib/gravatar.rb
@@ -68,16 +68,16 @@ module GravatarHelper
       email_hash = Digest::MD5.hexdigest(email)
       options = DEFAULT_OPTIONS.merge(options)
       options[:default] = CGI::escape(options[:default]) unless options[:default].nil?
-      returning gravatar_api_url(email_hash, options.delete(:ssl)) do |url|
-        opts = []
-        [:rating, :size, :default].each do |opt|
-          unless options[opt].nil?
-            value = h(options[opt])
-            opts << [opt, value].join('=')
-          end
-        end
-        url << "?#{opts.join('&')}" unless opts.empty?
+      url = gravatar_api_url(email_hash, options.delete(:ssl))
+      opts = []
+      [:rating, :size, :default].each do |opt|
+	unless options[opt].nil?
+	  value = h(options[opt])
+	  opts << [opt, value].join('=')
+	end
       end
+      url << "?#{opts.join('&')}" unless opts.empty?
+      url
     end
 
   end


### PR DESCRIPTION
Just return url explicitly so it works on all Rubies and Railses.

Ignore the branch name; that's what I thought I was going to do.
